### PR TITLE
Avoid trapped in db connecting state if mistakenly call db.open first and server connect afterward. 

### DIFF
--- a/lib/mongodb/connection/server.js
+++ b/lib/mongodb/connection/server.js
@@ -275,6 +275,7 @@ Server.prototype.connect = function(dbInstance, options, callback) {
     var connection = connectionPool.checkoutConnection();
     // Set server state to connected
     server._serverState = 'connected';
+    dbInstance._state = 'connected'; //Avoid trapped in db connecting state if mistakenly call db.open first and server connect afterward
 
     // Register handler for messages
     dbInstance._registerHandler(db_command, false, connection, connectHandler);


### PR DESCRIPTION
Avoid trapped in db connecting state if mistakenly call db.open first and server connect afterward. 

Client insert command will keep pushing to commands list if db._state is always connecting and set to autoreconnect.

Line 1886 in db.js method Db.prototype._executeInsertCommand:
if(self._state == 'connecting' && this.serverConfig.autoReconnect)
